### PR TITLE
Configure Netlify build output

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
-  publish = "."
+  command = "jekyll build"
+  publish = "_site"
   image = "focal"


### PR DESCRIPTION
## Summary
- configure Netlify build settings to run `jekyll build` and publish `_site`

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844a4ea6fd0832dba0ac959b6fe30dd