### PR TITLE
Replace hardcoded map key

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,10 @@ This repository contains the source for the CrafterAdam website.
 ## Netlify Deployment
 
 Netlify builds require a modern build image. The configuration in `netlify.toml` sets the build image to **focal** (Ubuntu 20.04). If your Netlify project is still using the deprecated Trusty image, ensure that this repository's configuration file is committed and that the project's build settings are updated accordingly.
+
+## Google Maps API Key
+
+The `map.html` page requires a Google Maps API key. Set an environment variable
+named `GOOGLE_MAPS_API_KEY` when building the site. On Netlify this can be
+configured in the build settings. During the build the variable is injected into
+`map.html` via `envsubst` so the deployed page includes the key.

--- a/map.html
+++ b/map.html
@@ -7,7 +7,7 @@
   <body>
     <div class="map"></div>
   
-   <script src="https://maps.google.com/maps/api/js?key=AIzaSyDi5js19F9I4YSPqiJnujsKQ5G4LrZ6dhs&amp;language=fr"></script>
+  <script src="https://maps.google.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&amp;language=fr"></script>
 
   <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
   <script src="https://cdn.jsdelivr.net/gmap3/7.2.0/gmap3.min.js"></script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [build]
   publish = "."
   image = "focal"
+  command = "envsubst < map.html > _map.html && mv _map.html map.html"


### PR DESCRIPTION
## Summary
- inject Google Maps API key via envsubst
- document API key setup

## Testing
- `GOOGLE_MAPS_API_KEY=TESTKEY envsubst < map.html | head`

------
https://chatgpt.com/codex/tasks/task_e_68449ed22644832d82df3a5eef6db690